### PR TITLE
feat(flux): add konflate for rendered PR review

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -55,6 +55,7 @@ AKS = "AKS"
 ## When the correction is the key, the word is *always* valid.
 [default.extend-words]
 "arange" = "arange"  # e.g. `numpy.arange`
+flate = "flate"  # home-operations/flate, konflate's render engine
 keypair = "keypair"
 raison = "raison"
 ba = "ba"

--- a/kubernetes/apps/flux-system/konflate/README.md
+++ b/kubernetes/apps/flux-system/konflate/README.md
@@ -1,0 +1,89 @@
+# Konflate
+
+[Konflate](https://github.com/home-operations/konflate) is a read-only pull request review tool for Flux.
+It renders every open PR against `main` with [flate](https://github.com/home-operations/flate) (the same tool the `Flate` CI workflow uses) and shows the diff of the _rendered_ Kubernetes resources — not the raw file diff.
+A one-line HelmRelease bump shows up as the actual resources that change, with blast-radius counts, container image changes, render failures, and danger flags (data-loss, RBAC, immutable-field changes).
+
+- **UI**: `https://konflate.${SECRET_DOMAIN}` (internal gateway only)
+- **Webhook**: `https://konflate-webhook.${SECRET_DOMAIN}/hooks` (external gateway, `/hooks` path only)
+- **Chart**: `oci://ghcr.io/home-operations/charts/konflate`
+- **Reference**: [onedr0p/home-ops konflate](https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/flux-system/konflate)
+
+## Configuration
+
+- `config.repo: github://ahgraber/homelab-gitops-k3s` — the repo it watches.
+- `config.clusterPath` is left empty (repo root) because this repo's Flux `spec.path` values are root-relative (`./kubernetes/...`), which is what flate resolves against.
+- `config.verifyImages: true` — HEAD-checks each newly referenced container image against its registry to catch typo'd or not-yet-pushed tags before they ImagePullBackOff.
+- **Write-back is on** (`statusChecks` + `prComments`): konflate posts a Check Run named `Konflate` on each PR head and one summary comment per PR, edited in place on every re-render.
+  Both link back to `config.publicUrl`.
+- **A repo-level webhook drives renders.**
+  Each push to a PR reaches `POST /hooks` and re-renders within seconds; the 30m poll (`refreshInterval`) stays as a missed-webhook backstop.
+  Only `/hooks` is exposed externally — the [webhook HTTPRoute](app/httproute.yaml) routes that one path through the Cloudflare tunnel, while the UI stays internal.
+  This mirrors the Flux `github-webhook` receiver, so every GitHub-to-cluster delivery lives under one repo Settings → Webhooks page.
+- `persistence` (2Gi ceph-block) keeps rendered diffs, the bare git mirror, and flate's helm caches across restarts.
+
+## Setup
+
+Konflate needs a GitHub App (write-back plus read auth) and a repo-level webhook (render triggers).
+The App and webhook are separate on purpose: the webhook joins the Flux receiver under repo Settings → Webhooks, while the App carries only the credential konflate writes with.
+All secrets live in one 1Password item, so the manifests never change when they rotate.
+
+### 1. Create the GitHub App
+
+1. Go to GitHub → Settings → Developer settings → GitHub Apps → **New GitHub App**.
+2. Name it (e.g. `konflate-homelab`), set any homepage URL, and **uncheck "Active" under Webhook** — the repo webhook (step 3) delivers events, not the App.
+3. Grant two repository permissions: **Checks: Read and write** (the Check Run) and **Pull requests: Read and write** (the summary comment).
+4. Create the App, copy its **Client ID** (`Iv23...`), and generate a **private key** (downloads a `.pem` file).
+5. Install the App on **only** `ahgraber/homelab-gitops-k3s`.
+
+### 2. Generate a webhook secret
+
+Generate a random HMAC secret GitHub signs its webhooks with: `openssl rand -hex 32`.
+Konflate rejects any delivery that fails this signature, so `/hooks` can safely face the internet.
+
+### 3. Add the repo-level webhook
+
+Go to the repo → Settings → Webhooks → **Add webhook** (the same page as the Flux `github-webhook`):
+
+- **Payload URL**: `https://konflate-webhook.${SECRET_DOMAIN}/hooks`
+- **Content type**: `application/json`
+- **Secret**: the value from step 2
+- **Events**: choose "Let me select individual events" and check **only Pull requests**.
+  That is the sole event konflate renders on — `synchronize` re-renders a PR when its head advances, and open/close/reopen re-list.
+  Do **not** add "Pushes": konflate ignores it (degrading to a wasteful full re-list), and pushing to a PR branch already fires a pull-request event.
+  Optionally add **Check runs**, **Check suites**, and **Statuses** if you want konflate's UI to reflect other CI checks' rollup on a PR; it is not needed for rendering.
+
+### 4. Create the 1Password item
+
+Create `flux-system.konflate` in the **homelab** vault with four fields:
+
+| Field           | Value                                    |
+| --------------- | ---------------------------------------- |
+| `token`         | a read-only PAT, or blank (see below)    |
+| `webhookSecret` | the HMAC secret (step 2)                 |
+| `appClientId`   | the App's Client ID (step 1)             |
+| `privateKey`    | the full contents of the `.pem` key file |
+
+The ExternalSecret maps these to `KONFLATE_TOKEN`, `KONFLATE_WEBHOOK_SECRET`, `KONFLATE_APP_CLIENT_ID`, and `KONFLATE_APP_PRIVATE_KEY`; the chart consumes them via `secret.existingSecret`.
+Konflate auto-detects the App's installation, so no installation ID is needed.
+The App already authenticates reads (raising the API rate limit), so `token` is optional — set a read-only PAT only if you want a fallback for when the App is unavailable.
+
+## Dependencies
+
+- rook-ceph (cache/state PVC)
+- external-secrets (`onepassword` ClusterSecretStore)
+- envoy-internal gateway (`network` namespace) — the UI
+- envoy-external gateway + cloudflared tunnel (`network` namespace) — the `/hooks` webhook
+- kube-prometheus-stack (ServiceMonitor)
+
+## Gotchas
+
+- **Single instance only** — konflate holds PR/diff state in memory and uses an RWO cache PVC; the Deployment uses `strategy: Recreate` and the chart rejects `replicaCount > 1`.
+- **Fork PRs are listed but never rendered** (`renderForkPrs: false`, the default) — rendering a fork runs untrusted code through flate (SSRF surface).
+  Renovate PRs are branches, not forks, so they render fine.
+- **Write-back credentials are checked once at startup.**
+  A bad or missing App credential disables write-back with a single log line rather than failing renders; restart the pod after fixing the 1Password item.
+- **PR-comment links only resolve from the home network** — `publicUrl` points at the internal-only hostname, so the "view in konflate" links need split DNS.
+  The check and comment still post regardless.
+- **Konflate's HTTP surface stays read-only** even with write-back on; only its own render loop posts, and the "copy to merge" button just puts a `gh pr merge ...` command on your clipboard.
+- With write-back live, the `flux-local` diff workflow is redundant; keep the `Flate` workflow, which validates rather than diffs.

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app konflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    config:
+      repo: github://ahgraber/homelab-gitops-k3s
+      # clusterPath stays empty: Flux spec.path values here are root-relative
+      # (./kubernetes/...), which is exactly what flate resolves against
+      verifyImages: true
+      # write-back via the GitHub App in the konflate secret (client id +
+      # private key); post a Check Run and an in-place summary comment per PR
+      statusChecks: true
+      prComments: true
+      publicUrl: https://konflate.${SECRET_DOMAIN}
+
+    secret:
+      existingSecret: *app
+
+    httpRoute:
+      enabled: true
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+          sectionName: https
+      hostnames:
+        - konflate.${SECRET_DOMAIN}
+
+    # keeps rendered diffs, the git mirror, and flate caches across restarts
+    persistence:
+      enabled: true
+      storageClass: ceph-block
+      size: 2Gi
+
+    monitoring:
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/flux-system/konflate/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# Webhook-only external route: exposes just POST /hooks so the GitHub App can
+# trigger immediate re-renders. The UI stays internal (chart httpRoute →
+# envoy-internal); external-dns publishes konflate-webhook.${SECRET_DOMAIN} as a
+# CNAME to external.${SECRET_DOMAIN} (the Cloudflare tunnel).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: konflate-webhook
+spec:
+  hostnames:
+    - "konflate-webhook.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /hooks
+      backendRefs:
+        - name: konflate
+          namespace: flux-system
+          port: 8080

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./source.yaml
+  - ./secret.externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/flux-system/konflate/app/secret.externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/secret.externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name konflate
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        # read-only forge token: raises the GitHub API rate limit; no write scope
+        KONFLATE_TOKEN: '{{ index . "token" }}'
+        # GitHub App for write-back: konflate mints short-lived installation
+        # tokens from these, so no standing write PAT lives in the cluster
+        KONFLATE_APP_CLIENT_ID: '{{ index . "appClientId" }}'
+        KONFLATE_APP_PRIVATE_KEY: '{{ index . "privateKey" }}'
+        # HMAC secret verifying the inbound repo webhook; enables POST /hooks
+        KONFLATE_WEBHOOK_SECRET: '{{ index . "webhookSecret" }}'
+  dataFrom:
+    - extract:
+        # op://homelab/flux-system.konflate/token
+        key: "flux-system.konflate"

--- a/kubernetes/apps/flux-system/konflate/app/source.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/source.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.0
+  url: oci://ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+spec:
+  targetNamespace: flux-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/flux-system/konflate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  wait: false

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   # Flux-Kustomizations
   - ./flux-operator/ks.yaml
   - ./flux-instance/ks.yaml
+  - ./konflate/ks.yaml


### PR DESCRIPTION
Deploy konflate, a read-only tool that renders open PRs as Flux resource diffs (via flate) rather than raw file diffs, surfacing blast radius, image changes, and danger flags.

- UI on the internal gateway; only POST /hooks is exposed externally through a dedicated webhook HTTPRoute on the Cloudflare tunnel
- render triggers via a repo-level webhook, mirroring the Flux receiver
- write-back (Check Run + PR comment) via a GitHub App, with reads and the webhook HMAC secret sourced from 1Password through ESO
- persist rendered diffs, the git mirror, and flate caches on ceph-block
- allowlist "flate" in typos config

AI-assistant: Claude Code